### PR TITLE
Add prod (start) and dev node startup scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "main": "index.js",
   "license": "MIT",
   "scripts": {
-    "server": "node index.js"
+    "start": "node index.js",
+    "server": "node index.js",
+    "dev": "nodemon index.js"
   },
   "dependencies": {
     "bcryptjs": "^2.4.3",


### PR DESCRIPTION
Heroku needs `start` script in the `package.json` file to start node. 