### PR TITLE
Temporarily disable route protection

### DIFF
--- a/routes/userRoutes.js
+++ b/routes/userRoutes.js
@@ -1,12 +1,12 @@
 const bcrypt = require("bcryptjs");
 const db = [];
-const { jwtCheck } = require("../auth/tokenService");
+//const { jwtCheck } = require("../auth/tokenService"); temporarily disabled during FE dev phase
 
 module.exports = server => {
 	server.post("/api/register", register);
 	server.post("/api/login", login);
 	server.get("/api/users/:id", users);
-	server.get("/api/users", jwtCheck, users);
+	server.get("/api/users", users);
 };
 
 /**


### PR DESCRIPTION
Disable route protection on `/users` endpoint to facilitate front-end development. No sensitive data is at risk during this phase.