### PR TITLE
use correct syntax for like operator

### DIFF
--- a/data/models/index.js
+++ b/data/models/index.js
@@ -18,7 +18,7 @@ async function search(search_string) {
 				.orderBy("first_name", "asc");
 		} else {
 			records = await db("Users")
-				.where("first_name", "like", `${search_string}`)
+				.where("first_name", "like", `%${search_string}%`)
 				.andWhere({ type: 2 })
 				.select("*")
 				.orderBy("first_name", "asc");


### PR DESCRIPTION
This will allow a user to type 'Geo' and still get 'George' as opposed to having to type in the full first name